### PR TITLE
Added required modules for DSCResources in compress task

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,3 +13,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Having modules available more than once results in: ImportCimAndScriptKeywordsFromModule : "A second CIM class definition
   for 'MSFT_PSRepository' was found while processing the schema file". Fixed that by using function 'Get-DscResourceFromModuleInFolder'.
   This usually happens with 'PackageManagement' and 'PowerShellGet'
+- Added required modules for DSCResources in compress task

--- a/source/Tasks/CompressModulesWithChecksum.build.ps1
+++ b/source/Tasks/CompressModulesWithChecksum.build.ps1
@@ -65,6 +65,12 @@ task CompressModulesWithChecksum {
         $modulesWithDscResources = Get-DscResourceFromModuleInFolder -ModuleFolder $RequiredModulesDirectory -Modules $allModules |
             Select-Object -ExpandProperty ModuleName -Unique
         $modulesWithDscResources = $allModules | Where-Object Name -In $modulesWithDscResources
+        #Added required modules for some DSCResources, example SharepointDSC with ReverseDSC
+        $dependentModulesWithNoDscResources = $modulesWithDscResources.RequiredModules | Where-Object Name -notin $modulesWithDscResources.Name |
+            Select-Object -ExpandProperty Name -Unique
+        $allModules | Where-Object Name -In $dependentModulesWithNoDscResources | ForEach-Object {
+            $modulesWithDscResources += $_
+        }
         #TODO: be more selective and maybe check based on the MOFs (but that's a lot of MOF to parse)
 
         foreach ($module in $modulesWithDscResources)


### PR DESCRIPTION
#### Pull Request (PR) description

The task 'CompressModulesWithChecksum' compresses only modules with DSCResources. But if a module had a RequiredModules in manifest, and these modules haven't a DSCResource, they are not compressed. 
So when you tried to add a module without it dependencies in Azure Automation Account, there is an error.

Example with SharepointDsc and ReverseDsc : 

![image](https://user-images.githubusercontent.com/25097989/150391417-de8d0aff-dcbf-4445-b377-6eee688174f2.png)

With these modifications, the requiredmodules of the DscResources modules are added in the compress task.

#### This Pull Request (PR) fixes the following issues

#### Task list

- [x] Added an entry to the change log under the Unreleased section of the file CHANGELOG.md.
      Entry should say what was changed and how that affects users (if applicable), and
      reference the issue being resolved (if applicable).
- [ ] Resource documentation added/updated in README.md.
- [ ] Resource parameter descriptions added/updated in README.md, schema.mof and comment-based
      help.
- [ ] Comment-based help added/updated.
- [ ] Localization strings added/updated in all localization files as appropriate.
- [ ] Examples appropriately added/updated.
- [ ] Unit tests added/updated. See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [ ] Integration tests added/updated (where possible). See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [x] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).
