### PR TITLE
Fixed RegEx to accept node names with dots and hyphans

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,4 +17,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   the DSC project that uses 'Sampler.DscPipeline'. Same applies to the Meta MOF compilation script 'RootMetaMof.ps1'. If these
   files don't exist, 'Sampler.DscPipeline' uses the scripts in 'ModuleRoot\Scripts'. To control which DSC composite and resource modules should be imported within the DSC configuration, add the section 'Sampler.DscPipeline' to the 'build.yml' as described
   on top of the file 'CompileRootConfiguration.ps1'.
-- Added error handling discovering 'CompileRootConfiguration.ps1' and 'RootMetaMof.ps1'
+- Added error handling discovering 'CompileRootConfiguration.ps1' and 'RootMetaMof.ps1'.
+- Fixed RegEx to accept node names with dots and hyphens.

--- a/source/Tasks/LoadDatumConfigData.build.ps1
+++ b/source/Tasks/LoadDatumConfigData.build.ps1
@@ -62,7 +62,7 @@ task LoadDatumConfigData {
         Filter           = $Filter
     }
 
-    if ($message = (&git log -1) -and $message -match "--Added new node '(?<NodeName>\w+)'")
+    if ($message = (&git log -1) -and $message -match "--Added new node '(?<NodeName>(\w|\.|-)+)'")
     {
         $global:Filter = $Filter = [scriptblock]::Create('$_.NodeName -eq "{0}"' -f $Matches.NodeName)
         $global:SkipCompressedModulesBuild = $true


### PR DESCRIPTION
#### Pull Request (PR) description

Starting a build for a single node (setting commit message to `--added new node '<NodeName>')` did not work if node name contained dots or hyphens.

#### This Pull Request (PR) fixes the following issues

#### Task list

- [x] Added an entry to the change log under the Unreleased section of the file CHANGELOG.md.
      Entry should say what was changed and how that affects users (if applicable), and
      reference the issue being resolved (if applicable).
- [ ] Resource documentation added/updated in README.md.
- [ ] Resource parameter descriptions added/updated in README.md, schema.mof and comment-based
      help.
- [ ] Comment-based help added/updated.
- [ ] Localization strings added/updated in all localization files as appropriate.
- [ ] Examples appropriately added/updated.
- [ ] Unit tests added/updated. See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [ ] Integration tests added/updated (where possible). See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [x] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).
