### PR TITLE
Removed 'RequiredModules' attribute in PSD1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Removed
+
+- RequiredModules attribute in PSD1 which cause to broke dependencies with new version of that modules
+
 ### Added
 
 - Adding pipeline tasks and commands from DSC Workshop.

--- a/source/Sampler.DscPipeline.psd1
+++ b/source/Sampler.DscPipeline.psd1
@@ -42,13 +42,6 @@
     # Processor architecture (None, X86, Amd64) required by this module
     # ProcessorArchitecture = ''
 
-    # Modules that must be imported into the global environment prior to importing this module
-    RequiredModules = @(
-        'Plaster'
-        'Sampler'
-        'DscBuildHelpers'
-    )
-
     # Assemblies that must be loaded prior to importing this module
     # RequiredAssemblies = @()
 


### PR DESCRIPTION

#### Description

This attribute causes to download the latest version of the specified modules (e.g: Plater, Sampler, DscBuildHelpers). This behaviour happens also when someone runs `build.ps1 -ResolveDependency`, which causes dependency to broke (no matter what specified in `RequiredModules.psd1`).

In particular, given my `RequiredModules.psd1`

```
'Sampler.DscPipeline'        = '0.2.0-preview0001'
DscBuildHelpers              = '0.0.42'
```

I have got issue because of the new version (0.2.0) of `DscBuildHelpers`. 

#### Task list

- [x] Added an entry to the change log under the Unreleased section of the file CHANGELOG.md.
      Entry should say what was changed and how that affects users (if applicable), and
      reference the issue being resolved (if applicable).
- [ ] Resource documentation added/updated in README.md.
- [ ] Resource parameter descriptions added/updated in README.md, schema.mof and comment-based
      help.
- [ ] Comment-based help added/updated.
- [ ] Localization strings added/updated in all localization files as appropriate.
- [ ] Examples appropriately added/updated.
- [ ] Unit tests added/updated. See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [ ] Integration tests added/updated (where possible). See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [ ] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).
