### PR TITLE
Allowing NodeName is different to Name for checksum calc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,3 +20,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added error handling discovering 'CompileRootConfiguration.ps1' and 'RootMetaMof.ps1'
 - Test cases updated to Pester 5.
 - Fixing issue with ZipFile class not being present
+- Fixing calculation of checksum if attribute NodeName is different to attribute Name (of YAML file)

--- a/source/Tasks/NewMofChecksums.build.ps1
+++ b/source/Tasks/NewMofChecksums.build.ps1
@@ -28,7 +28,8 @@ task NewMofChecksums {
     $mofs = Get-ChildItem -Path $MofOutputFolder -Recurse -ErrorAction SilentlyContinue
     foreach ($mof in $mofs)
     {
-        if ($mof.BaseName -in $global:configurationData.AllNodes.Name)
+        if (($mof.BaseName -in $global:configurationData.AllNodes.Name) -or 
+            ($mof.BaseName -in $global:configurationData.AllNodes.NodeName))
         {
             New-DscChecksum -Path $mof.FullName -Verbose:$false -Force
         }


### PR DESCRIPTION
#### Pull Request (PR) description

fixing calculation of checksum if attribute NodeName is different to attribute Name (of YAML file)

#### Task list

- [X] Added an entry to the change log under the Unreleased section of the file CHANGELOG.md.
      Entry should say what was changed and how that affects users (if applicable), and
      reference the issue being resolved (if applicable).
- [ ] Resource documentation added/updated in README.md.
- [ ] Resource parameter descriptions added/updated in README.md, schema.mof and comment-based
      help.
- [ ] Comment-based help added/updated.
- [ ] Localization strings added/updated in all localization files as appropriate.
- [ ] Examples appropriately added/updated.
- [ ] Unit tests added/updated. See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [ ] Integration tests added/updated (where possible). See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [X] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/synedgy/sampler.dscpipeline/14)
<!-- Reviewable:end -->
