### PR TITLE
Reset PSModulePath after MOF compilation of each node

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Increase build speed of root configuration by only importing required Composites/Resources
 - Added ''UseEnvironment'' parameter to cater for RSOP for identical node names in different environments
 - Adding Home.md to wikiSource and correct casing.
+- Reset PSModulePath after MOF compilation of each node to avoid duplicate CIM class definition errors on the following nodes
 
 ### Fixed
 


### PR DESCRIPTION
#### Pull Request (PR) description

Reset PSModulePath after MOF compilation of each node to avoid duplicate CIM class definition errors on the following nodes

#### Task list

- [X] Added an entry to the change log under the Unreleased section of the file CHANGELOG.md.
      Entry should say what was changed and how that affects users (if applicable), and
      reference the issue being resolved (if applicable).
- [ ] Resource documentation added/updated in README.md.
- [ ] Resource parameter descriptions added/updated in README.md, schema.mof and comment-based
      help.
- [ ] Comment-based help added/updated.
- [ ] Localization strings added/updated in all localization files as appropriate.
- [ ] Examples appropriately added/updated.
- [ ] Unit tests added/updated. See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [ ] Integration tests added/updated (where possible). See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [X] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/SynEdgy/Sampler.DscPipeline/21)
<!-- Reviewable:end -->
