### PR TITLE
Calling `Split-Array` only if `TotalJobCount` more than 1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Increase build speed of root configuration by only importing required Composites/Resources
 - Added ''UseEnvironment'' parameter to cater for RSOP for identical node names in different environments
 - Adding Home.md to wikiSource and correct casing.
-- Redesign of the function Split-Array. Most of the time it was not working as expected, especially when requesting larger ChunkCounts (see AutomatedLab/AutomatedLab.Common/#118)
+- Redesign of the function Split-Array. Most of the time it was not working as expected, especially when requesting larger ChunkCounts (see AutomatedLab/AutomatedLab.Common/#118).
 - Improved error handling when compiling MOF files.
 
 ### Fixed

--- a/source/Public/Get-FilteredConfigurationData.ps1
+++ b/source/Public/Get-FilteredConfigurationData.ps1
@@ -51,7 +51,10 @@ function Get-FilteredConfigurationData
     }
 
     $CurrentJobNumber--
-    $allDatumNodes = Split-Array -List $allDatumNodes -ChunkCount $TotalJobCount
+    if ($TotalJobCount -gt 1)
+    {
+        $allDatumNodes = Split-Array -List $allDatumNodes -ChunkCount $TotalJobCount
+    }
     $allDatumNodes = $allDatumNodes[$CurrentJobNumber]
 
     return @{

--- a/source/Public/Get-FilteredConfigurationData.ps1
+++ b/source/Public/Get-FilteredConfigurationData.ps1
@@ -55,7 +55,7 @@ function Get-FilteredConfigurationData
     {
         $allDatumNodes = Split-Array -List $allDatumNodes -ChunkCount $TotalJobCount
     }
-    $allDatumNodes = $allDatumNodes[$CurrentJobNumber]
+    $allDatumNodes = @($allDatumNodes[$CurrentJobNumber])
 
     return @{
         AllNodes = $allDatumNodes


### PR DESCRIPTION
#### Pull Request (PR) description

The redesign of `Split-Array` in #22 added new validation for parameter `ChunkCount`:

```powershell
[ValidateRange(2, [long]::MaxValue)]
[int]
$ChunkCount,
```

>Note: No changelog entry added as this should have been part of #22.

The method should only be called when the is more than one worker / job.

#### This Pull Request (PR) fixes the following issues

NA

#### Task list

- [ ] Added an entry to the change log under the Unreleased section of the file CHANGELOG.md.
      Entry should say what was changed and how that affects users (if applicable), and
      reference the issue being resolved (if applicable).
- [ ] Resource documentation added/updated in README.md.
- [ ] Resource parameter descriptions added/updated in README.md, schema.mof and comment-based
      help.
- [ ] Comment-based help added/updated.
- [ ] Localization strings added/updated in all localization files as appropriate.
- [ ] Examples appropriately added/updated.
- [ ] Unit tests added/updated. See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [ ] Integration tests added/updated (where possible). See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [x] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/SynEdgy/Sampler.DscPipeline/25)
<!-- Reviewable:end -->
