### PR TITLE
Fix PSModulePath handling in CompileRootConfiguration task, fixes #43

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Fix parsing of UseEnvironment parameter in CompileDatumRsop task ([#39](https://github.com/SynEdgy/Sampler.DscPipeline/issues/39))
+- Fix parsing of UseEnvironment parameter in CompileDatumRsop task ([#39](https://github.com/SynEdgy/Sampler.DscPipeline/issues/39)).
+- Fixed `Initialize-DscResourceMetaInfo` changed the module path and broke DSC builds in PowerShell 7 / PSDesiredStateConfiguration 2.0.7 (Fixes #43) by saving and restoring the `PSModulePath`.
 
 ## [0.2.0] - 2024-11-09
 

--- a/source/Tasks/CompileRootConfiguration.build.ps1
+++ b/source/Tasks/CompileRootConfiguration.build.ps1
@@ -46,9 +46,11 @@ task CompileRootConfiguration {
 
     $RequiredModulesDirectory = Get-SamplerAbsolutePath -Path $RequiredModulesDirectory -RelativeTo $OutputDirectory
 
+    $previousPSModulePath = $env:PSModulePath
     Write-Build DarkGray 'Reading DSC Resource metadata for supporting CIM based DSC parameters...'
     Initialize-DscResourceMetaInfo -ModulePath $RequiredModulesDirectory
     Write-Build DarkGray 'Done'
+    $env:PSModulePath = $previousPSModulePath
 
     $MofOutputFolder = Get-SamplerAbsolutePath -Path $MofOutputFolder -RelativeTo $OutputDirectory
 


### PR DESCRIPTION
#### Pull Request (PR) description

Fixed `Initialize-DscResourceMetaInfo` changed the module path and broke DSC builds in PowerShell 7 / PSDesiredStateConfiguration 2.0.7 (Fixes #43) by saving and restoring the `PSModulePath`.

#### This Pull Request (PR) fixes the following issues

- Fixes #43 

#### Task list

- [x] Added an entry to the change log under the Unreleased section of the file CHANGELOG.md.
      Entry should say what was changed and how that affects users (if applicable), and
      reference the issue being resolved (if applicable).
- [ ] Resource documentation added/updated in README.md.
- [ ] Resource parameter descriptions added/updated in README.md, schema.mof and comment-based
      help.
- [ ] Comment-based help added/updated.
- [ ] Localization strings added/updated in all localization files as appropriate.
- [ ] Examples appropriately added/updated.
- [ ] Unit tests added/updated. See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [ ] Integration tests added/updated (where possible). See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [x] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/SynEdgy/Sampler.DscPipeline/44)
<!-- Reviewable:end -->
