### PR TITLE
Comment out 'Publish_GitHub_Wiki_Content' in the publish workflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed `Initialize-DscResourceMetaInfo` changed the module path and broke DSC builds in PowerShell 7 / PSDesiredStateConfiguration 2.0.7 (Fixes #43) by saving and restoring the `PSModulePath`.
 - Fixed error handling in case a DSC resource could not be loaded.
 
+### Changed
+
+- Comment out `Publish_GitHub_Wiki_Content` in the publish workflow as it doesn't work now and this project doesn't have a wiki.
+
 ## [0.2.0] - 2024-11-09
 
 ### Added

--- a/build.yaml
+++ b/build.yaml
@@ -57,7 +57,7 @@ BuildWorkflow:
   publish:
     - publish_module_to_gallery
     - Publish_Release_To_GitHub
-    - Publish_GitHub_Wiki_Content
+    #- Publish_GitHub_Wiki_Content
     - Create_ChangeLog_GitHub_PR
 
 ####################################################


### PR DESCRIPTION
#### Pull Request (PR) description

Comment out `Publish_GitHub_Wiki_Content` in the publish workflow as it doesn't work now and this project doesn't have a wiki.

#### This Pull Request (PR) fixes the following issues

NA

#### Task list

- [x] Added an entry to the change log under the Unreleased section of the file CHANGELOG.md.
      Entry should say what was changed and how that affects users (if applicable), and
      reference the issue being resolved (if applicable).
- [ ] Resource documentation added/updated in README.md.
- [ ] Resource parameter descriptions added/updated in README.md, schema.mof and comment-based
      help.
- [ ] Comment-based help added/updated.
- [ ] Localization strings added/updated in all localization files as appropriate.
- [ ] Examples appropriately added/updated.
- [ ] Unit tests added/updated. See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [ ] Integration tests added/updated (where possible). See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [x] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/SynEdgy/Sampler.DscPipeline/45)
<!-- Reviewable:end -->
